### PR TITLE
feat: Implement Compiler and Executor

### DIFF
--- a/registry/actions.yaml
+++ b/registry/actions.yaml
@@ -1,55 +1,303 @@
-# Capability Registry - Actions
+# Capability Registry - Actions v1.0
 # All supported actions that Plan IR can reference
+# Based on fsq-mac CLI v0.2.1
 
 schema_version: "1.0"
 
 actions:
-  # Application control
-  activate_app:
-    description: Activate/focus an application
-    args:
-      app_name: {type: string, required: true}
-    compile_to: osascript -e 'tell application "{app_name}" to activate'
-    expected_evidence: [process_running]
-    default_retry: {max: 3, backoff: linear}
-  
-  # Keyboard actions
-  hotkey:
-    description: Send keyboard hotkey
-    args:
-      keys: {type: array, required: true}
-    compile_to: mac input hotkey {keys}
-    expected_evidence: [command_output]
-    default_retry: {max: 2, backoff: none}
-  
-  type_text:
-    description: Type text
-    args:
-      text: {type: string, required: true}
-    compile_to: mac input type "{text}"
-    expected_evidence: [command_output]
-    default_retry: {max: 2, backoff: none}
-  
-  # Session management
+  # ============================================================
+  # SESSION MANAGEMENT
+  # ============================================================
   session_start:
-    description: Start fsq-mac session
+    description: Start a new fsq-mac automation session
     args: {}
     compile_to: mac session start
     expected_evidence: [session_id]
     default_retry: {max: 3, backoff: exponential}
+    danger_level: safe
+    tags: [session, lifecycle]
   
   session_end:
-    description: End fsq-mac session
+    description: End the current fsq-mac session
     args: {}
     compile_to: mac session end
     expected_evidence: [command_output]
     default_retry: {max: 1, backoff: none}
+    danger_level: safe
+    tags: [session, lifecycle]
+
+  # ============================================================
+  # APPLICATION CONTROL
+  # ============================================================
+  activate_app:
+    description: Activate/focus an application
+    args:
+      app_name: {type: string, required: true, description: "Application name"}
+    compile_to: osascript -e 'tell application "{app_name}" to activate'
+    expected_evidence: [process_running]
+    preconditions: [session_active]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [app, focus]
+
+  launch_app:
+    description: Launch an application
+    args:
+      bundle_id: {type: string, required: true, description: "App bundle identifier"}
+    compile_to: mac app launch {bundle_id}
+    expected_evidence: [process_running, command_output]
+    default_retry: {max: 3, backoff: exponential}
+    danger_level: safe
+    tags: [app, launch]
+
+  terminate_app:
+    description: Terminate an application
+    args:
+      bundle_id: {type: string, required: true}
+    compile_to: mac app terminate {bundle_id}
+    expected_evidence: [command_output]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: warning
+    repair_hints: ["Check if app has unsaved data"]
+    tags: [app, terminate]
+
+  # ============================================================
+  # ELEMENT OPERATIONS
+  # ============================================================
+  element_click:
+    description: Click an element by locator
+    args:
+      locator: {type: string, required: true, description: "Element locator"}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element click "{locator}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    preconditions: [session_active, app_focused]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [element, click, interaction]
+
+  element_right_click:
+    description: Right-click an element
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element right-click "{locator}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: safe
+    tags: [element, click, context_menu]
+
+  element_double_click:
+    description: Double-click an element
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element double-click "{locator}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: safe
+    tags: [element, click]
+
+  element_type:
+    description: Type text into an element
+    args:
+      locator: {type: string, required: true}
+      text: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element type "{locator}" "{text}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    default_retry: {max: 2, backoff: none}
+    danger_level: safe
+    tags: [element, type, input]
+
+  element_scroll:
+    description: Scroll an element
+    args:
+      locator: {type: string, required: true}
+      direction: {type: string, required: true, enum: [up, down, left, right]}
+      amount: {type: integer, required: false, default: 100}
+    compile_to: mac element scroll "{locator}" --direction {direction} --amount {amount}
+    expected_evidence: [command_output]
+    default_retry: {max: 2, backoff: none}
+    danger_level: safe
+    tags: [element, scroll]
+
+  element_hover:
+    description: Hover over an element
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element hover "{locator}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: safe
+    tags: [element, hover]
+
+  element_find:
+    description: Find elements by locator
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac element find "{locator}" --strategy {strategy}
+    expected_evidence: [element_found, command_output]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [element, find, query]
+
+  # ============================================================
+  # DIRECT INPUT (no element targeting)
+  # ============================================================
+  hotkey:
+    description: Send keyboard hotkey
+    args:
+      keys: {type: array, required: true, description: "Key combination e.g. ['cmd', 't']"}
+    compile_to: mac input hotkey {keys}
+    expected_evidence: [command_output]
+    preconditions: [session_active, app_focused]
+    default_retry: {max: 2, backoff: none}
+    danger_level: safe
+    tags: [input, keyboard, hotkey]
   
-  # Wait/delay
+  type_text:
+    description: Type text directly (no element focus)
+    args:
+      text: {type: string, required: true}
+    compile_to: mac input type "{text}"
+    expected_evidence: [command_output]
+    preconditions: [session_active]
+    default_retry: {max: 2, backoff: none}
+    danger_level: safe
+    tags: [input, keyboard, type]
+
+  # ============================================================
+  # ASSERTIONS
+  # ============================================================
+  assert_visible:
+    description: Assert element is visible
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac assert visible "{locator}" --strategy {strategy}
+    expected_evidence: [assertion_result, element_found]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [assert, visibility]
+
+  assert_enabled:
+    description: Assert element is enabled
+    args:
+      locator: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac assert enabled "{locator}" --strategy {strategy}
+    expected_evidence: [assertion_result]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [assert, state]
+
+  assert_text:
+    description: Assert element has expected text
+    args:
+      locator: {type: string, required: true}
+      expected: {type: string, required: true}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac assert text "{locator}" "{expected}" --strategy {strategy}
+    expected_evidence: [assertion_result]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [assert, text, content]
+
+  assert_value:
+    description: Assert element has expected value
+    args:
+      locator: {type: string, required: true}
+      expected: {type: string, required: true}
+    compile_to: mac assert value "{locator}" "{expected}"
+    expected_evidence: [assertion_result]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [assert, value]
+
+  # ============================================================
+  # CAPTURE / EVIDENCE
+  # ============================================================
+  capture_screenshot:
+    description: Take a screenshot
+    args:
+      output: {type: string, required: false, default: "screenshot.png"}
+    compile_to: mac capture screenshot --output {output}
+    expected_evidence: [screenshot]
+    default_retry: {max: 2, backoff: none}
+    danger_level: safe
+    tags: [capture, screenshot, evidence]
+
+  capture_ui_tree:
+    description: Capture UI element tree
+    args:
+      output: {type: string, required: false, default: "ui_tree.json"}
+    compile_to: mac capture ui-tree --output {output}
+    expected_evidence: [ui_tree]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: safe
+    tags: [capture, ui_tree, evidence]
+
+  # ============================================================
+  # WAIT / TIMING
+  # ============================================================
   wait:
     description: Wait for specified time
     args:
-      ms: {type: integer, required: true}
+      ms: {type: integer, required: true, description: "Milliseconds to wait"}
     compile_to: sleep {ms}ms
     expected_evidence: []
     default_retry: {max: 1, backoff: none}
+    danger_level: safe
+    tags: [wait, timing]
+
+  wait_for_element:
+    description: Wait until element appears
+    args:
+      locator: {type: string, required: true}
+      timeout_ms: {type: integer, required: false, default: 10000}
+      strategy: {type: string, required: false, default: "accessibility_id"}
+    compile_to: mac wait element "{locator}" --timeout {timeout_ms} --strategy {strategy}
+    expected_evidence: [element_found]
+    default_retry: {max: 1, backoff: none}
+    danger_level: safe
+    tags: [wait, element]
+
+  # ============================================================
+  # MENU OPERATIONS
+  # ============================================================
+  menu_select:
+    description: Select a menu item
+    args:
+      menu_path: {type: array, required: true, description: "Menu path e.g. ['File', 'New Tab']"}
+    compile_to: mac menu select {menu_path}
+    expected_evidence: [command_output]
+    preconditions: [session_active, app_focused]
+    default_retry: {max: 2, backoff: linear}
+    danger_level: safe
+    tags: [menu, select]
+
+  # ============================================================
+  # WINDOW MANAGEMENT
+  # ============================================================
+  window_focus:
+    description: Focus a window by title
+    args:
+      title: {type: string, required: true}
+    compile_to: mac window focus "{title}"
+    expected_evidence: [command_output]
+    default_retry: {max: 3, backoff: linear}
+    danger_level: safe
+    tags: [window, focus]
+
+  window_close:
+    description: Close current window
+    args: {}
+    compile_to: mac window close
+    expected_evidence: [command_output]
+    default_retry: {max: 1, backoff: none}
+    danger_level: warning
+    repair_hints: ["May trigger save dialog"]
+    tags: [window, close]

--- a/registry/schema.yaml
+++ b/registry/schema.yaml
@@ -1,0 +1,45 @@
+# Capability Registry Schema v1.0
+# Defines the structure for action registration
+
+schema_version: "1.0"
+
+action_schema:
+  required_fields:
+    - description      # Human-readable description
+    - args             # Argument schema
+    - compile_to       # fsq-mac CLI command template
+    - expected_evidence # What evidence to collect
+    - default_retry    # Retry policy
+
+  optional_fields:
+    - preconditions    # Required state before execution
+    - postconditions   # Expected state after execution
+    - repair_hints     # Suggestions for failure recovery
+    - tags             # Categorization tags
+    - danger_level     # safe | warning | dangerous
+
+  arg_types:
+    - string
+    - integer
+    - boolean
+    - array
+    - object
+
+  evidence_types:
+    - command_output   # CLI stdout/stderr
+    - screenshot       # Screen capture
+    - ui_tree          # Accessibility tree
+    - session_id       # Session identifier
+    - process_running  # Process check
+    - element_found    # Element located
+    - assertion_result # Assert pass/fail
+
+  retry_backoff:
+    - none
+    - linear
+    - exponential
+
+  danger_levels:
+    safe: "No side effects, safe to retry"
+    warning: "May modify state, confirm before retry"
+    dangerous: "Irreversible action, requires --allow-dangerous"

--- a/src/compiler/compiler.py
+++ b/src/compiler/compiler.py
@@ -1,0 +1,125 @@
+"""
+Plan IR Compiler - Compiles Plan IR steps into executable CLI commands.
+"""
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import yaml
+
+
+class CompilerError(Exception):
+    """Raised when compilation fails."""
+    pass
+
+
+class Compiler:
+    """Compiles Plan IR steps into fsq-mac CLI commands."""
+    
+    def __init__(self, registry_path: Optional[Path] = None):
+        """Initialize compiler with action registry."""
+        if registry_path is None:
+            registry_path = Path(__file__).parent.parent.parent / "registry" / "actions.yaml"
+        self.registry = self._load_registry(registry_path)
+    
+    def _load_registry(self, path: Path) -> Dict[str, Any]:
+        """Load action registry from YAML file."""
+        if not path.exists():
+            raise CompilerError(f"Registry not found: {path}")
+        with open(path, "r") as f:
+            data = yaml.safe_load(f)
+        return data.get("actions", {})
+    
+    def compile_step(self, step: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Compile a single Plan IR step into CLI command.
+        
+        Args:
+            step: Plan IR step with action and args
+            
+        Returns:
+            Compiled step with 'command' field added
+        """
+        action_name = step.get("action")
+        if not action_name:
+            raise CompilerError("Step missing 'action' field")
+        
+        if action_name not in self.registry:
+            raise CompilerError(f"Unknown action: {action_name}")
+        
+        action_def = self.registry[action_name]
+        args = step.get("args", {})
+        
+        # Validate required args
+        for arg_name, arg_spec in action_def.get("args", {}).items():
+            if arg_spec.get("required", False) and arg_name not in args:
+                raise CompilerError(f"Missing required arg '{arg_name}' for action '{action_name}'")
+        
+        # Fill in defaults
+        for arg_name, arg_spec in action_def.get("args", {}).items():
+            if arg_name not in args and "default" in arg_spec:
+                args[arg_name] = arg_spec["default"]
+        
+        # Compile template
+        command = self._compile_template(action_def["compile_to"], args)
+        
+        return {
+            **step,
+            "command": command,
+            "expected_evidence": action_def.get("expected_evidence", []),
+            "retry_policy": step.get("retry_policy", action_def.get("default_retry", {})),
+        }
+    
+    def _compile_template(self, template: str, args: Dict[str, Any]) -> str:
+        """Compile command template with arguments."""
+        result = template
+        for key, value in args.items():
+            placeholder = "{" + key + "}"
+            if placeholder in result:
+                if isinstance(value, list):
+                    # Handle array args (e.g., hotkey keys)
+                    value_str = " ".join(str(v) for v in value)
+                else:
+                    value_str = str(value)
+                result = result.replace(placeholder, value_str)
+        return result
+    
+    def compile_plan(self, plan: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Compile entire Plan IR into executable plan.
+        
+        Args:
+            plan: Plan IR with steps
+            
+        Returns:
+            Compiled plan with all steps having 'command' fields
+        """
+        compiled_steps = []
+        for step in plan.get("steps", []):
+            compiled_steps.append(self.compile_step(step))
+        
+        return {
+            **plan,
+            "steps": compiled_steps,
+            "compiled": True,
+        }
+
+
+def load_registry(path: str) -> Dict[str, Any]:
+    """Load action registry from path."""
+    compiler = Compiler(Path(path))
+    return compiler.registry
+
+
+def compile_step(step: Dict[str, Any], registry_path: Optional[str] = None) -> Dict[str, Any]:
+    """Compile a single step."""
+    path = Path(registry_path) if registry_path else None
+    compiler = Compiler(path)
+    return compiler.compile_step(step)
+
+
+def compile_plan(plan: Dict[str, Any], registry_path: Optional[str] = None) -> Dict[str, Any]:
+    """Compile entire plan."""
+    path = Path(registry_path) if registry_path else None
+    compiler = Compiler(path)
+    return compiler.compile_plan(plan)

--- a/src/executor/executor.py
+++ b/src/executor/executor.py
@@ -1,0 +1,276 @@
+"""
+Unified Executor - Executes compiled Plan IR steps and collects evidence.
+"""
+import json
+import os
+import subprocess
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+import uuid
+
+
+class ExecutionError(Exception):
+    """Raised when execution fails."""
+    pass
+
+
+class StepResult:
+    """Result of executing a single step."""
+    
+    def __init__(
+        self,
+        step_id: str,
+        success: bool,
+        command: str,
+        stdout: str = "",
+        stderr: str = "",
+        return_code: int = 0,
+        duration_ms: int = 0,
+        evidence: Optional[Dict[str, Any]] = None,
+        error: Optional[str] = None,
+    ):
+        self.step_id = step_id
+        self.success = success
+        self.command = command
+        self.stdout = stdout
+        self.stderr = stderr
+        self.return_code = return_code
+        self.duration_ms = duration_ms
+        self.evidence = evidence or {}
+        self.error = error
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "step_id": self.step_id,
+            "success": self.success,
+            "command": self.command,
+            "stdout": self.stdout,
+            "stderr": self.stderr,
+            "return_code": self.return_code,
+            "duration_ms": self.duration_ms,
+            "evidence": self.evidence,
+            "error": self.error,
+        }
+
+
+class PlanResult:
+    """Result of executing an entire plan."""
+    
+    def __init__(self, plan_id: str, run_id: str):
+        self.plan_id = plan_id
+        self.run_id = run_id
+        self.start_time = datetime.utcnow().isoformat()
+        self.end_time: Optional[str] = None
+        self.success = True
+        self.step_results: List[StepResult] = []
+        self.failure_reason: Optional[str] = None
+    
+    def add_step_result(self, result: StepResult):
+        self.step_results.append(result)
+        if not result.success:
+            self.success = False
+    
+    def finalize(self, failure_reason: Optional[str] = None):
+        self.end_time = datetime.utcnow().isoformat()
+        self.failure_reason = failure_reason
+    
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "plan_id": self.plan_id,
+            "run_id": self.run_id,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "success": self.success,
+            "failure_reason": self.failure_reason,
+            "step_results": [r.to_dict() for r in self.step_results],
+        }
+
+
+class Executor:
+    """Executes compiled Plan IR steps."""
+    
+    def __init__(self, runs_dir: Optional[Path] = None, timeout_ms: int = 120000):
+        """Initialize executor."""
+        if runs_dir is None:
+            runs_dir = Path(__file__).parent.parent.parent / "runs"
+        self.runs_dir = runs_dir
+        self.timeout_ms = timeout_ms
+        self.mac_cli = os.environ.get("FSQ_MAC_CLI", "mac")
+    
+    def execute_command(self, command: str, timeout_ms: Optional[int] = None) -> Dict[str, Any]:
+        """
+        Execute a single CLI command.
+        
+        Returns:
+            Dict with stdout, stderr, return_code, duration_ms
+        """
+        timeout = (timeout_ms or self.timeout_ms) / 1000.0
+        start = time.time()
+        
+        try:
+            result = subprocess.run(
+                command,
+                shell=True,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+            duration_ms = int((time.time() - start) * 1000)
+            return {
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "return_code": result.returncode,
+                "duration_ms": duration_ms,
+            }
+        except subprocess.TimeoutExpired:
+            duration_ms = int((time.time() - start) * 1000)
+            return {
+                "stdout": "",
+                "stderr": f"Command timed out after {timeout}s",
+                "return_code": -1,
+                "duration_ms": duration_ms,
+            }
+        except Exception as e:
+            duration_ms = int((time.time() - start) * 1000)
+            return {
+                "stdout": "",
+                "stderr": str(e),
+                "return_code": -2,
+                "duration_ms": duration_ms,
+            }
+    
+    def execute_step(self, step: Dict[str, Any]) -> StepResult:
+        """
+        Execute a single compiled step.
+        
+        Args:
+            step: Compiled step with 'command' field
+            
+        Returns:
+            StepResult with execution details
+        """
+        step_id = step.get("step_id", "unknown")
+        command = step.get("command")
+        
+        if not command:
+            return StepResult(
+                step_id=step_id,
+                success=False,
+                command="",
+                error="Step missing 'command' field - not compiled?",
+            )
+        
+        # Execute with retry
+        retry_policy = step.get("retry_policy", {})
+        max_attempts = retry_policy.get("max", 1)
+        backoff = retry_policy.get("backoff", "none")
+        delay_ms = retry_policy.get("delay_ms", 1000)
+        
+        last_result = None
+        for attempt in range(max_attempts):
+            result = self.execute_command(command)
+            last_result = result
+            
+            if result["return_code"] == 0:
+                return StepResult(
+                    step_id=step_id,
+                    success=True,
+                    command=command,
+                    stdout=result["stdout"],
+                    stderr=result["stderr"],
+                    return_code=result["return_code"],
+                    duration_ms=result["duration_ms"],
+                    evidence={
+                        "command_output": result["stdout"],
+                        "attempt": attempt + 1,
+                    },
+                )
+            
+            # Backoff before retry
+            if attempt < max_attempts - 1:
+                if backoff == "linear":
+                    time.sleep(delay_ms * (attempt + 1) / 1000.0)
+                elif backoff == "exponential":
+                    time.sleep(delay_ms * (2 ** attempt) / 1000.0)
+                else:
+                    time.sleep(delay_ms / 1000.0)
+        
+        return StepResult(
+            step_id=step_id,
+            success=False,
+            command=command,
+            stdout=last_result.get("stdout", ""),
+            stderr=last_result.get("stderr", ""),
+            return_code=last_result.get("return_code", -1),
+            duration_ms=last_result.get("duration_ms", 0),
+            error=f"Failed after {max_attempts} attempts",
+        )
+    
+    def execute_plan(self, plan: Dict[str, Any]) -> PlanResult:
+        """
+        Execute an entire compiled plan.
+        
+        Args:
+            plan: Compiled plan with steps
+            
+        Returns:
+            PlanResult with all step results
+        """
+        plan_id = plan.get("plan_id", "unknown")
+        run_id = str(uuid.uuid4())[:8]
+        
+        result = PlanResult(plan_id, run_id)
+        
+        for step in plan.get("steps", []):
+            step_result = self.execute_step(step)
+            result.add_step_result(step_result)
+            
+            # Check on_fail policy
+            if not step_result.success:
+                on_fail = step.get("on_fail", "abort")
+                if on_fail == "abort":
+                    result.finalize(f"Step {step_result.step_id} failed, aborting")
+                    break
+                elif on_fail == "skip":
+                    continue
+                elif on_fail == "human_review":
+                    result.finalize(f"Step {step_result.step_id} requires human review")
+                    break
+        else:
+            result.finalize()
+        
+        # Save evidence to runs directory
+        self._save_evidence(result)
+        
+        return result
+    
+    def _save_evidence(self, result: PlanResult):
+        """Save execution evidence to runs directory."""
+        run_dir = self.runs_dir / result.run_id
+        run_dir.mkdir(parents=True, exist_ok=True)
+        
+        # Save result JSON
+        with open(run_dir / "result.json", "w") as f:
+            json.dump(result.to_dict(), f, indent=2)
+
+
+def execute_command(command: str) -> Dict[str, Any]:
+    """Execute a single CLI command."""
+    executor = Executor()
+    return executor.execute_command(command)
+
+
+def execute_step(step: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute a single compiled step."""
+    executor = Executor()
+    result = executor.execute_step(step)
+    return result.to_dict()
+
+
+def execute_plan(plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute an entire compiled plan."""
+    executor = Executor()
+    result = executor.execute_plan(plan)
+    return result.to_dict()

--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -1,0 +1,99 @@
+"""Unit tests for Compiler."""
+import pytest
+from src.compiler.compiler import Compiler, CompilerError, compile_step, compile_plan
+
+
+class TestCompiler:
+    """Test Compiler class."""
+    
+    def test_compile_simple_step(self):
+        """Test compiling a simple step."""
+        compiler = Compiler()
+        step = {
+            "step_id": "step_1",
+            "action": "session_start",
+            "args": {},
+        }
+        result = compiler.compile_step(step)
+        assert result["command"] == "mac session start"
+        assert "session_id" in result["expected_evidence"]
+    
+    def test_compile_step_with_args(self):
+        """Test compiling step with arguments."""
+        compiler = Compiler()
+        step = {
+            "step_id": "step_2",
+            "action": "activate_app",
+            "args": {"app_name": "Safari"},
+        }
+        result = compiler.compile_step(step)
+        assert "Safari" in result["command"]
+        assert "activate" in result["command"]
+    
+    def test_compile_step_missing_required_arg(self):
+        """Test that missing required arg raises error."""
+        compiler = Compiler()
+        step = {
+            "step_id": "step_3",
+            "action": "activate_app",
+            "args": {},  # Missing app_name
+        }
+        with pytest.raises(CompilerError, match="Missing required arg"):
+            compiler.compile_step(step)
+    
+    def test_compile_unknown_action(self):
+        """Test that unknown action raises error."""
+        compiler = Compiler()
+        step = {
+            "step_id": "step_4",
+            "action": "unknown_action",
+            "args": {},
+        }
+        with pytest.raises(CompilerError, match="Unknown action"):
+            compiler.compile_step(step)
+    
+    def test_compile_plan(self):
+        """Test compiling entire plan."""
+        compiler = Compiler()
+        plan = {
+            "plan_id": "test_plan",
+            "steps": [
+                {"step_id": "s1", "action": "session_start", "args": {}},
+                {"step_id": "s2", "action": "wait", "args": {"ms": 1000}},
+                {"step_id": "s3", "action": "session_end", "args": {}},
+            ],
+        }
+        result = compiler.compile_plan(plan)
+        assert result["compiled"] is True
+        assert len(result["steps"]) == 3
+        assert all("command" in s for s in result["steps"])
+    
+    def test_compile_hotkey(self):
+        """Test compiling hotkey action with array args."""
+        compiler = Compiler()
+        step = {
+            "step_id": "step_5",
+            "action": "hotkey",
+            "args": {"keys": ["cmd", "t"]},
+        }
+        result = compiler.compile_step(step)
+        assert "cmd t" in result["command"]
+
+
+class TestHelperFunctions:
+    """Test module-level helper functions."""
+    
+    def test_compile_step_function(self):
+        """Test compile_step helper."""
+        step = {"step_id": "s1", "action": "session_start", "args": {}}
+        result = compile_step(step)
+        assert "command" in result
+    
+    def test_compile_plan_function(self):
+        """Test compile_plan helper."""
+        plan = {
+            "plan_id": "p1",
+            "steps": [{"step_id": "s1", "action": "session_start", "args": {}}],
+        }
+        result = compile_plan(plan)
+        assert result["compiled"] is True

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,145 @@
+"""Unit tests for Executor."""
+import pytest
+from unittest.mock import patch, MagicMock
+from src.executor.executor import Executor, StepResult, PlanResult, execute_command
+
+
+class TestExecutor:
+    """Test Executor class."""
+    
+    def test_execute_simple_command(self):
+        """Test executing a simple command."""
+        executor = Executor()
+        result = executor.execute_command("echo hello")
+        assert result["return_code"] == 0
+        assert "hello" in result["stdout"]
+        assert result["duration_ms"] >= 0
+    
+    def test_execute_failing_command(self):
+        """Test executing a failing command."""
+        executor = Executor()
+        result = executor.execute_command("false")
+        assert result["return_code"] != 0
+    
+    def test_execute_step_success(self):
+        """Test executing a compiled step successfully."""
+        executor = Executor()
+        step = {
+            "step_id": "s1",
+            "command": "echo success",
+            "retry_policy": {"max": 1},
+        }
+        result = executor.execute_step(step)
+        assert result.success is True
+        assert "success" in result.stdout
+    
+    def test_execute_step_with_retry(self):
+        """Test step execution with retry on failure."""
+        executor = Executor()
+        step = {
+            "step_id": "s2",
+            "command": "false",  # Always fails
+            "retry_policy": {"max": 2, "backoff": "none", "delay_ms": 10},
+        }
+        result = executor.execute_step(step)
+        assert result.success is False
+        assert "2 attempts" in result.error
+    
+    def test_execute_step_missing_command(self):
+        """Test step without command field."""
+        executor = Executor()
+        step = {"step_id": "s3"}  # No command
+        result = executor.execute_step(step)
+        assert result.success is False
+        assert "not compiled" in result.error
+    
+    def test_execute_plan(self):
+        """Test executing entire plan."""
+        executor = Executor()
+        plan = {
+            "plan_id": "test_plan",
+            "steps": [
+                {"step_id": "s1", "command": "echo step1"},
+                {"step_id": "s2", "command": "echo step2"},
+            ],
+        }
+        result = executor.execute_plan(plan)
+        assert result.success is True
+        assert len(result.step_results) == 2
+    
+    def test_execute_plan_abort_on_failure(self):
+        """Test plan aborts on step failure with on_fail=abort."""
+        executor = Executor()
+        plan = {
+            "plan_id": "test_plan",
+            "steps": [
+                {"step_id": "s1", "command": "echo ok"},
+                {"step_id": "s2", "command": "false", "on_fail": "abort"},
+                {"step_id": "s3", "command": "echo never"},
+            ],
+        }
+        result = executor.execute_plan(plan)
+        assert result.success is False
+        assert len(result.step_results) == 2  # s3 not executed
+        assert "aborting" in result.failure_reason.lower()
+    
+    def test_execute_plan_skip_on_failure(self):
+        """Test plan continues with on_fail=skip."""
+        executor = Executor()
+        plan = {
+            "plan_id": "test_plan",
+            "steps": [
+                {"step_id": "s1", "command": "echo ok"},
+                {"step_id": "s2", "command": "false", "on_fail": "skip"},
+                {"step_id": "s3", "command": "echo continued"},
+            ],
+        }
+        result = executor.execute_plan(plan)
+        assert len(result.step_results) == 3  # All executed
+        assert result.step_results[2].success is True
+
+
+class TestStepResult:
+    """Test StepResult class."""
+    
+    def test_to_dict(self):
+        """Test StepResult serialization."""
+        result = StepResult(
+            step_id="s1",
+            success=True,
+            command="echo test",
+            stdout="test\n",
+            duration_ms=10,
+        )
+        d = result.to_dict()
+        assert d["step_id"] == "s1"
+        assert d["success"] is True
+        assert d["command"] == "echo test"
+
+
+class TestPlanResult:
+    """Test PlanResult class."""
+    
+    def test_add_step_result(self):
+        """Test adding step results."""
+        plan_result = PlanResult("p1", "r1")
+        step_result = StepResult("s1", True, "echo ok")
+        plan_result.add_step_result(step_result)
+        assert len(plan_result.step_results) == 1
+        assert plan_result.success is True
+    
+    def test_failure_propagation(self):
+        """Test that step failure marks plan as failed."""
+        plan_result = PlanResult("p1", "r1")
+        plan_result.add_step_result(StepResult("s1", True, "echo ok"))
+        plan_result.add_step_result(StepResult("s2", False, "false"))
+        assert plan_result.success is False
+
+
+class TestHelperFunctions:
+    """Test module-level helper functions."""
+    
+    def test_execute_command_function(self):
+        """Test execute_command helper."""
+        result = execute_command("echo hello")
+        assert result["return_code"] == 0


### PR DESCRIPTION
## Compiler + Executor 实现

### Compiler (src/compiler/compiler.py)
- `load_registry()` - 加载 actions.yaml
- `compile_step()` - 编译单个 Plan IR step → CLI 命令
- `compile_plan()` - 编译整个计划
- 模板变量替换 `{arg_name}`
- 必填参数验证
- 默认参数填充

### Executor (src/executor/executor.py)
- `execute_command()` - 执行 CLI 命令，支持超时
- `execute_step()` - 带重试策略执行
- `execute_plan()` - 执行整个计划，处理 on_fail
- 证据采集并保存到 `runs/<run-id>/`
- StepResult 和 PlanResult 数据类

### Registry
- 扩展 actions.yaml（25+ actions）
- 新增 registry/schema.yaml

### 单元测试
- tests/unit/test_compiler.py
- tests/unit/test_executor.py

Closes #3
Closes #4