### PR TITLE
feat: Implement Plan IR and Evidence Schemas

### DIFF
--- a/schemas/evidence.schema.json
+++ b/schemas/evidence.schema.json
@@ -1,0 +1,156 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Evidence Schema",
+  "description": "Execution results and evidence",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["evidence_id", "plan_id", "run_id", "status", "steps"],
+  "properties": {
+    "evidence_id": {
+      "type": "string",
+      "description": "Unique evidence identifier",
+      "pattern": "^evidence-[a-z0-9-]+$"
+    },
+    "plan_id": {
+      "type": "string",
+      "description": "Reference to executed plan"
+    },
+    "run_id": {
+      "type": "string",
+      "description": "Unique run identifier"
+    },
+    "version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["success", "partial", "failure", "aborted"],
+      "description": "Overall execution status"
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "finished_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "duration_ms": {
+      "type": "integer",
+      "description": "Total execution time in milliseconds"
+    },
+    "environment": {
+      "type": "object",
+      "properties": {
+        "os": {"type": "string"},
+        "os_version": {"type": "string"},
+        "hostname": {"type": "string"},
+        "executor_version": {"type": "string"}
+      }
+    },
+    "steps": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/step_result"}
+    },
+    "assertions": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/assertion_result"}
+    },
+    "repairs": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/repair_attempt"}
+    },
+    "artifacts": {
+      "type": "object",
+      "description": "Paths to artifact files",
+      "properties": {
+        "screenshots_dir": {"type": "string"},
+        "ui_trees_dir": {"type": "string"},
+        "logs_dir": {"type": "string"}
+      }
+    }
+  },
+  "definitions": {
+    "step_result": {
+      "type": "object",
+      "required": ["step_id", "action", "status"],
+      "properties": {
+        "step_id": {"type": "string"},
+        "action": {"type": "string"},
+        "status": {
+          "type": "string",
+          "enum": ["success", "failure", "skipped", "repaired"]
+        },
+        "started_at": {"type": "string", "format": "date-time"},
+        "finished_at": {"type": "string", "format": "date-time"},
+        "duration_ms": {"type": "integer"},
+        "cli_command": {
+          "type": "object",
+          "properties": {
+            "command": {"type": "array", "items": {"type": "string"}},
+            "exit_code": {"type": "integer"},
+            "stdout": {"type": "string"},
+            "stderr": {"type": "string"}
+          }
+        },
+        "error": {
+          "type": "object",
+          "properties": {
+            "type": {"type": "string"},
+            "message": {"type": "string"},
+            "classification": {
+              "type": "string",
+              "enum": [
+                "plan_invalid",
+                "precondition_missing",
+                "capability_unavailable",
+                "environment_failure",
+                "observation_insufficient",
+                "assertion_failed"
+              ]
+            }
+          }
+        },
+        "evidence": {
+          "type": "object",
+          "properties": {
+            "screenshot_before": {"type": "string", "description": "Path or base64"},
+            "screenshot_after": {"type": "string"},
+            "ui_tree_before": {"type": "string"},
+            "ui_tree_after": {"type": "string"}
+          }
+        },
+        "retry_count": {"type": "integer", "default": 0}
+      }
+    },
+    "assertion_result": {
+      "type": "object",
+      "required": ["assertion_id", "passed"],
+      "properties": {
+        "assertion_id": {"type": "string"},
+        "step_id": {"type": "string"},
+        "condition": {"type": "string"},
+        "passed": {"type": "boolean"},
+        "actual_value": {"type": "string"},
+        "expected_value": {"type": "string"},
+        "review_required": {"type": "boolean"}
+      }
+    },
+    "repair_attempt": {
+      "type": "object",
+      "required": ["step_id", "strategy", "success"],
+      "properties": {
+        "step_id": {"type": "string"},
+        "failure_type": {"type": "string"},
+        "strategy": {
+          "type": "string",
+          "enum": ["retry", "restart_session", "replan_step", "skip", "human_review"]
+        },
+        "attempt_number": {"type": "integer"},
+        "success": {"type": "boolean"},
+        "details": {"type": "string"}
+      }
+    }
+  }
+}

--- a/schemas/examples/edge-new-tab.plan.json
+++ b/schemas/examples/edge-new-tab.plan.json
@@ -1,0 +1,35 @@
+{
+  "plan_id": "plan-edge-new-tab",
+  "version": "1.0.0",
+  "goal": "Test Edge new tab creation",
+  "app": "Microsoft Edge",
+  "created_at": "2026-04-09T14:00:00+08:00",
+  "steps": [
+    {
+      "step_id": "step-1-launch",
+      "action": "launch",
+      "params": {"app": "Microsoft Edge"},
+      "expected_signal": "app_active",
+      "retry_policy": {"max_attempts": 2}
+    },
+    {
+      "step_id": "step-2-capture-baseline",
+      "action": "capture",
+      "params": {"type": "ui_tree"},
+      "expected_signal": "captured"
+    },
+    {
+      "step_id": "step-3-new-tab",
+      "action": "shortcut",
+      "params": {"keys": ["command", "t"]},
+      "expected_signal": "tab_count_increased",
+      "evidence": {"screenshot_before": true, "screenshot_after": true}
+    },
+    {
+      "step_id": "step-4-verify",
+      "action": "assert",
+      "params": {"condition": "tab_count > baseline.tab_count"},
+      "review_required": true
+    }
+  ]
+}

--- a/schemas/examples/finder-new-folder.plan.json
+++ b/schemas/examples/finder-new-folder.plan.json
@@ -1,0 +1,14 @@
+{
+  "plan_id": "plan-finder-new-folder",
+  "version": "1.0.0",
+  "goal": "Create a new folder in Finder",
+  "app": "Finder",
+  "steps": [
+    {"step_id": "s1", "action": "launch", "params": {"app": "Finder"}},
+    {"step_id": "s2", "action": "shortcut", "params": {"keys": ["command", "shift", "n"]}},
+    {"step_id": "s3", "action": "wait", "params": {"seconds": 0.5}},
+    {"step_id": "s4", "action": "type", "params": {"text": "TestFolder"}},
+    {"step_id": "s5", "action": "shortcut", "params": {"keys": ["return"]}},
+    {"step_id": "s6", "action": "assert", "params": {"condition": "folder_exists(\"TestFolder\")"}}
+  ]
+}

--- a/schemas/examples/partial-with-repair.evidence.json
+++ b/schemas/examples/partial-with-repair.evidence.json
@@ -1,0 +1,58 @@
+{
+  "evidence_id": "evidence-20260409-002",
+  "plan_id": "plan-safari-navigate",
+  "run_id": "run-e5f6g7h8",
+  "version": "1.0.0",
+  "status": "partial",
+  "started_at": "2026-04-09T14:10:00+08:00",
+  "finished_at": "2026-04-09T14:10:15+08:00",
+  "duration_ms": 15000,
+  "environment": {
+    "os": "macOS",
+    "os_version": "14.0",
+    "hostname": "test-mac",
+    "executor_version": "1.0.0"
+  },
+  "steps": [
+    {
+      "step_id": "s1",
+      "action": "launch",
+      "status": "success",
+      "duration_ms": 2000,
+      "cli_command": {
+        "command": ["osascript", "-e", "tell app \"Safari\" to activate"],
+        "exit_code": 0
+      }
+    },
+    {
+      "step_id": "s2",
+      "action": "shortcut",
+      "status": "repaired",
+      "duration_ms": 3000,
+      "cli_command": {
+        "command": ["mac", "input", "hotkey", "command", "l"],
+        "exit_code": 0
+      },
+      "error": {
+        "type": "SessionLost",
+        "message": "Appium session disconnected",
+        "classification": "environment_failure"
+      },
+      "retry_count": 1
+    }
+  ],
+  "repairs": [
+    {
+      "step_id": "s2",
+      "failure_type": "environment_failure",
+      "strategy": "restart_session",
+      "attempt_number": 1,
+      "success": true,
+      "details": "Restarted Appium session, retry successful"
+    }
+  ],
+  "artifacts": {
+    "screenshots_dir": "runs/run-e5f6g7h8/screenshots/",
+    "logs_dir": "runs/run-e5f6g7h8/logs/"
+  }
+}

--- a/schemas/examples/safari-navigate.plan.json
+++ b/schemas/examples/safari-navigate.plan.json
@@ -1,0 +1,14 @@
+{
+  "plan_id": "plan-safari-navigate",
+  "version": "1.0.0",
+  "goal": "Navigate Safari to example.com",
+  "app": "Safari",
+  "steps": [
+    {"step_id": "s1", "action": "launch", "params": {"app": "Safari"}},
+    {"step_id": "s2", "action": "shortcut", "params": {"keys": ["command", "l"]}},
+    {"step_id": "s3", "action": "type", "params": {"text": "https://example.com"}},
+    {"step_id": "s4", "action": "shortcut", "params": {"keys": ["return"]}},
+    {"step_id": "s5", "action": "wait", "params": {"seconds": 2}},
+    {"step_id": "s6", "action": "assert", "params": {"condition": "url.contains(\"example.com\")"}}
+  ]
+}

--- a/schemas/examples/success.evidence.json
+++ b/schemas/examples/success.evidence.json
@@ -1,0 +1,58 @@
+{
+  "evidence_id": "evidence-20260409-001",
+  "plan_id": "plan-edge-new-tab",
+  "run_id": "run-a1b2c3d4",
+  "version": "1.0.0",
+  "status": "success",
+  "started_at": "2026-04-09T14:00:00+08:00",
+  "finished_at": "2026-04-09T14:00:05+08:00",
+  "duration_ms": 5000,
+  "environment": {
+    "os": "macOS",
+    "os_version": "14.0",
+    "hostname": "test-mac",
+    "executor_version": "1.0.0"
+  },
+  "steps": [
+    {
+      "step_id": "step-1-launch",
+      "action": "launch",
+      "status": "success",
+      "duration_ms": 2000,
+      "cli_command": {
+        "command": ["osascript", "-e", "tell app \"Microsoft Edge\" to activate"],
+        "exit_code": 0,
+        "stdout": ""
+      }
+    },
+    {
+      "step_id": "step-3-new-tab",
+      "action": "shortcut",
+      "status": "success",
+      "duration_ms": 500,
+      "cli_command": {
+        "command": ["mac", "input", "hotkey", "command", "t"],
+        "exit_code": 0
+      },
+      "evidence": {
+        "screenshot_before": "runs/run-a1b2c3d4/screenshots/step-3-before.png",
+        "screenshot_after": "runs/run-a1b2c3d4/screenshots/step-3-after.png"
+      }
+    }
+  ],
+  "assertions": [
+    {
+      "assertion_id": "assert-tab-count",
+      "step_id": "step-4-verify",
+      "condition": "tab_count > baseline.tab_count",
+      "passed": true,
+      "actual_value": "2",
+      "expected_value": ">1"
+    }
+  ],
+  "artifacts": {
+    "screenshots_dir": "runs/run-a1b2c3d4/screenshots/",
+    "ui_trees_dir": "runs/run-a1b2c3d4/ui_trees/",
+    "logs_dir": "runs/run-a1b2c3d4/logs/"
+  }
+}

--- a/schemas/plan-ir.schema.json
+++ b/schemas/plan-ir.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Plan IR Schema",
+  "description": "Intermediate Representation for execution plans",
+  "version": "1.0.0",
+  "type": "object",
+  "required": ["plan_id", "version", "goal", "app", "steps"],
+  "properties": {
+    "plan_id": {
+      "type": "string",
+      "description": "Unique plan identifier",
+      "pattern": "^plan-[a-z0-9-]+$"
+    },
+    "version": {
+      "type": "string",
+      "description": "Schema version",
+      "const": "1.0.0"
+    },
+    "goal": {
+      "type": "string",
+      "description": "Original goal in natural language"
+    },
+    "app": {
+      "type": "string",
+      "description": "Target application bundle ID or name"
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "author": {"type": "string"},
+        "tags": {"type": "array", "items": {"type": "string"}},
+        "timeout_ms": {"type": "integer", "default": 60000}
+      }
+    },
+    "preconditions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["check"],
+        "properties": {
+          "check": {"type": "string"},
+          "expected": {"type": "string"},
+          "on_fail": {"type": "string", "enum": ["abort", "warn"]}
+        }
+      }
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/definitions/step"}
+    }
+  },
+  "definitions": {
+    "step": {
+      "type": "object",
+      "required": ["step_id", "action"],
+      "properties": {
+        "step_id": {
+          "type": "string",
+          "description": "Unique step identifier within plan"
+        },
+        "action": {
+          "type": "string",
+          "enum": ["launch", "shortcut", "type", "click", "wait", "assert", "capture"]
+        },
+        "params": {
+          "oneOf": [
+            {"$ref": "#/definitions/launch_params"},
+            {"$ref": "#/definitions/shortcut_params"},
+            {"$ref": "#/definitions/type_params"},
+            {"$ref": "#/definitions/click_params"},
+            {"$ref": "#/definitions/wait_params"},
+            {"$ref": "#/definitions/assert_params"},
+            {"$ref": "#/definitions/capture_params"}
+          ]
+        },
+        "expected_signal": {
+          "type": "string",
+          "description": "What indicates success"
+        },
+        "retry_policy": {"$ref": "#/definitions/retry_policy"},
+        "on_fail": {
+          "type": "string",
+          "enum": ["abort", "skip", "replan", "human_review"],
+          "default": "abort"
+        },
+        "review_required": {
+          "type": "boolean",
+          "default": false
+        },
+        "evidence": {
+          "type": "object",
+          "properties": {
+            "screenshot_before": {"type": "boolean"},
+            "screenshot_after": {"type": "boolean"},
+            "capture_ui_tree": {"type": "boolean"}
+          }
+        }
+      }
+    },
+    "launch_params": {
+      "type": "object",
+      "required": ["app"],
+      "properties": {
+        "app": {"type": "string", "description": "App name or bundle ID"}
+      }
+    },
+    "shortcut_params": {
+      "type": "object",
+      "required": ["keys"],
+      "properties": {
+        "keys": {
+          "type": "array",
+          "items": {"type": "string"},
+          "description": "Key combination, e.g. [\"command\", \"t\"]"
+        }
+      }
+    },
+    "type_params": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {"type": "string"},
+        "delay_ms": {"type": "integer", "default": 50}
+      }
+    },
+    "click_params": {
+      "type": "object",
+      "properties": {
+        "selector": {"type": "string", "description": "Accessibility selector"},
+        "x": {"type": "number"},
+        "y": {"type": "number"},
+        "button": {"type": "string", "enum": ["left", "right"], "default": "left"}
+      }
+    },
+    "wait_params": {
+      "type": "object",
+      "properties": {
+        "seconds": {"type": "number"},
+        "condition": {"type": "string"},
+        "timeout_ms": {"type": "integer", "default": 10000}
+      }
+    },
+    "assert_params": {
+      "type": "object",
+      "required": ["condition"],
+      "properties": {
+        "condition": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    },
+    "capture_params": {
+      "type": "object",
+      "properties": {
+        "type": {"type": "string", "enum": ["screenshot", "ui_tree", "both"]},
+        "selector": {"type": "string"}
+      }
+    },
+    "retry_policy": {
+      "type": "object",
+      "properties": {
+        "max_attempts": {"type": "integer", "default": 3, "minimum": 1},
+        "backoff": {"type": "string", "enum": ["none", "linear", "exponential"], "default": "linear"},
+        "delay_ms": {"type": "integer", "default": 1000}
+      }
+    }
+  }
+}

--- a/src/schema/__init__.py
+++ b/src/schema/__init__.py
@@ -1,0 +1,18 @@
+"""Schema validation module."""
+from .validator import (
+    SchemaValidator,
+    SchemaValidationError,
+    validate_plan,
+    validate_evidence,
+    validate_plan_file,
+    validate_evidence_file,
+)
+
+__all__ = [
+    "SchemaValidator",
+    "SchemaValidationError",
+    "validate_plan",
+    "validate_evidence",
+    "validate_plan_file",
+    "validate_evidence_file",
+]

--- a/src/schema/validator.py
+++ b/src/schema/validator.py
@@ -1,0 +1,112 @@
+"""
+Schema Validator - Validates Plan IR and Evidence against JSON Schema.
+"""
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+import jsonschema
+from jsonschema import Draft7Validator
+
+
+class SchemaValidationError(Exception):
+    """Raised when schema validation fails."""
+    def __init__(self, errors: List[str]):
+        self.errors = errors
+        super().__init__(f"Validation failed with {len(errors)} error(s)")
+
+
+class SchemaValidator:
+    """Validates JSON data against schemas."""
+    
+    def __init__(self, schemas_dir: Optional[Path] = None):
+        """Initialize validator with schemas directory."""
+        if schemas_dir is None:
+            schemas_dir = Path(__file__).parent.parent.parent / "schemas"
+        self.schemas_dir = schemas_dir
+        self._schemas: Dict[str, Dict] = {}
+    
+    def _load_schema(self, schema_name: str) -> Dict[str, Any]:
+        """Load and cache a schema by name."""
+        if schema_name not in self._schemas:
+            schema_path = self.schemas_dir / f"{schema_name}.schema.json"
+            if not schema_path.exists():
+                raise FileNotFoundError(f"Schema not found: {schema_path}")
+            with open(schema_path, "r") as f:
+                self._schemas[schema_name] = json.load(f)
+        return self._schemas[schema_name]
+    
+    def validate(self, data: Dict[str, Any], schema_name: str) -> Tuple[bool, List[str]]:
+        """
+        Validate data against a schema.
+        
+        Args:
+            data: JSON data to validate
+            schema_name: Schema name (without .schema.json extension)
+            
+        Returns:
+            Tuple of (is_valid, list_of_errors)
+        """
+        schema = self._load_schema(schema_name)
+        validator = Draft7Validator(schema)
+        errors = []
+        
+        for error in sorted(validator.iter_errors(data), key=lambda e: e.path):
+            path = ".".join(str(p) for p in error.path) or "(root)"
+            errors.append(f"{path}: {error.message}")
+        
+        return len(errors) == 0, errors
+    
+    def validate_or_raise(self, data: Dict[str, Any], schema_name: str) -> None:
+        """Validate data and raise exception if invalid."""
+        is_valid, errors = self.validate(data, schema_name)
+        if not is_valid:
+            raise SchemaValidationError(errors)
+    
+    def validate_plan(self, plan: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        """Validate a Plan IR document."""
+        return self.validate(plan, "plan-ir")
+    
+    def validate_evidence(self, evidence: Dict[str, Any]) -> Tuple[bool, List[str]]:
+        """Validate an Evidence document."""
+        return self.validate(evidence, "evidence")
+    
+    def validate_plan_file(self, path: Path) -> Tuple[bool, List[str]]:
+        """Validate a Plan IR JSON file."""
+        with open(path, "r") as f:
+            data = json.load(f)
+        return self.validate_plan(data)
+    
+    def validate_evidence_file(self, path: Path) -> Tuple[bool, List[str]]:
+        """Validate an Evidence JSON file."""
+        with open(path, "r") as f:
+            data = json.load(f)
+        return self.validate_evidence(data)
+
+
+# Module-level convenience functions
+def validate_plan(plan: Dict[str, Any], schemas_dir: Optional[str] = None) -> Tuple[bool, List[str]]:
+    """Validate a Plan IR document."""
+    path = Path(schemas_dir) if schemas_dir else None
+    validator = SchemaValidator(path)
+    return validator.validate_plan(plan)
+
+
+def validate_evidence(evidence: Dict[str, Any], schemas_dir: Optional[str] = None) -> Tuple[bool, List[str]]:
+    """Validate an Evidence document."""
+    path = Path(schemas_dir) if schemas_dir else None
+    validator = SchemaValidator(path)
+    return validator.validate_evidence(evidence)
+
+
+def validate_plan_file(path: str, schemas_dir: Optional[str] = None) -> Tuple[bool, List[str]]:
+    """Validate a Plan IR JSON file."""
+    schemas_path = Path(schemas_dir) if schemas_dir else None
+    validator = SchemaValidator(schemas_path)
+    return validator.validate_plan_file(Path(path))
+
+
+def validate_evidence_file(path: str, schemas_dir: Optional[str] = None) -> Tuple[bool, List[str]]:
+    """Validate an Evidence JSON file."""
+    schemas_path = Path(schemas_dir) if schemas_dir else None
+    validator = SchemaValidator(schemas_path)
+    return validator.validate_evidence_file(Path(path))

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -1,0 +1,189 @@
+"""Unit tests for Schema Validator."""
+import pytest
+import json
+from pathlib import Path
+from src.schema.validator import (
+    SchemaValidator,
+    SchemaValidationError,
+    validate_plan,
+    validate_evidence,
+)
+
+
+class TestSchemaValidator:
+    """Test SchemaValidator class."""
+    
+    @pytest.fixture
+    def validator(self):
+        return SchemaValidator()
+    
+    def test_validate_valid_plan(self, validator):
+        """Test validating a valid Plan IR."""
+        plan = {
+            "plan_id": "plan-test-001",
+            "version": "1.0.0",
+            "goal": "Test goal",
+            "app": "Safari",
+            "steps": [
+                {
+                    "step_id": "s1",
+                    "action": "launch",
+                    "params": {"app": "Safari"}
+                }
+            ]
+        }
+        is_valid, errors = validator.validate_plan(plan)
+        assert is_valid is True
+        assert len(errors) == 0
+    
+    def test_validate_plan_missing_required_fields(self, validator):
+        """Test that missing required fields cause validation errors."""
+        plan = {
+            "plan_id": "plan-test-002",
+            # Missing: version, goal, app, steps
+        }
+        is_valid, errors = validator.validate_plan(plan)
+        assert is_valid is False
+        assert len(errors) >= 4  # At least 4 missing fields
+    
+    def test_validate_plan_invalid_action(self, validator):
+        """Test that invalid action type is rejected."""
+        plan = {
+            "plan_id": "plan-test-003",
+            "version": "1.0.0",
+            "goal": "Test",
+            "app": "Safari",
+            "steps": [
+                {
+                    "step_id": "s1",
+                    "action": "invalid_action"  # Not in enum
+                }
+            ]
+        }
+        is_valid, errors = validator.validate_plan(plan)
+        assert is_valid is False
+        assert any("action" in e.lower() for e in errors)
+    
+    def test_validate_plan_invalid_id_pattern(self, validator):
+        """Test that invalid plan_id pattern is rejected."""
+        plan = {
+            "plan_id": "INVALID_ID",  # Must match ^plan-[a-z0-9-]+$
+            "version": "1.0.0",
+            "goal": "Test",
+            "app": "Safari",
+            "steps": [{"step_id": "s1", "action": "launch"}]
+        }
+        is_valid, errors = validator.validate_plan(plan)
+        assert is_valid is False
+        assert any("plan_id" in e for e in errors)
+    
+    def test_validate_valid_evidence(self, validator):
+        """Test validating valid Evidence."""
+        evidence = {
+            "evidence_id": "evidence-test-001",
+            "plan_id": "plan-test-001",
+            "run_id": "run-abc123",
+            "status": "success",
+            "steps": [
+                {
+                    "step_id": "s1",
+                    "action": "launch",
+                    "status": "success"
+                }
+            ]
+        }
+        is_valid, errors = validator.validate_evidence(evidence)
+        assert is_valid is True
+        assert len(errors) == 0
+    
+    def test_validate_evidence_invalid_status(self, validator):
+        """Test that invalid status is rejected."""
+        evidence = {
+            "evidence_id": "evidence-test-002",
+            "plan_id": "plan-test-001",
+            "run_id": "run-abc123",
+            "status": "unknown",  # Not in enum
+            "steps": []
+        }
+        is_valid, errors = validator.validate_evidence(evidence)
+        assert is_valid is False
+        assert any("status" in e.lower() for e in errors)
+    
+    def test_validate_or_raise(self, validator):
+        """Test validate_or_raise raises exception on invalid data."""
+        invalid_plan = {"plan_id": "invalid"}
+        with pytest.raises(SchemaValidationError) as exc_info:
+            validator.validate_or_raise(invalid_plan, "plan-ir")
+        assert len(exc_info.value.errors) > 0
+
+
+class TestValidatePlanExamples:
+    """Test validation of example plan files."""
+    
+    @pytest.fixture
+    def validator(self):
+        return SchemaValidator()
+    
+    def test_edge_new_tab_example(self, validator):
+        """Test edge-new-tab.plan.json example."""
+        path = Path(__file__).parent.parent.parent / "schemas" / "examples" / "edge-new-tab.plan.json"
+        if path.exists():
+            is_valid, errors = validator.validate_plan_file(path)
+            assert is_valid is True, f"Errors: {errors}"
+    
+    def test_safari_navigate_example(self, validator):
+        """Test safari-navigate.plan.json example."""
+        path = Path(__file__).parent.parent.parent / "schemas" / "examples" / "safari-navigate.plan.json"
+        if path.exists():
+            is_valid, errors = validator.validate_plan_file(path)
+            assert is_valid is True, f"Errors: {errors}"
+
+
+class TestValidateEvidenceExamples:
+    """Test validation of example evidence files."""
+    
+    @pytest.fixture
+    def validator(self):
+        return SchemaValidator()
+    
+    def test_success_evidence_example(self, validator):
+        """Test success.evidence.json example."""
+        path = Path(__file__).parent.parent.parent / "schemas" / "examples" / "success.evidence.json"
+        if path.exists():
+            is_valid, errors = validator.validate_evidence_file(path)
+            assert is_valid is True, f"Errors: {errors}"
+    
+    def test_partial_repair_evidence_example(self, validator):
+        """Test partial-with-repair.evidence.json example."""
+        path = Path(__file__).parent.parent.parent / "schemas" / "examples" / "partial-with-repair.evidence.json"
+        if path.exists():
+            is_valid, errors = validator.validate_evidence_file(path)
+            assert is_valid is True, f"Errors: {errors}"
+
+
+class TestHelperFunctions:
+    """Test module-level helper functions."""
+    
+    def test_validate_plan_function(self):
+        """Test validate_plan helper."""
+        plan = {
+            "plan_id": "plan-test-func",
+            "version": "1.0.0",
+            "goal": "Test",
+            "app": "Safari",
+            "steps": [{"step_id": "s1", "action": "launch"}]
+        }
+        is_valid, errors = validate_plan(plan)
+        assert is_valid is True
+    
+    def test_validate_evidence_function(self):
+        """Test validate_evidence helper."""
+        evidence = {
+            "evidence_id": "evidence-test-func",
+            "plan_id": "plan-test",
+            "run_id": "run-123",
+            "status": "success",
+            "steps": []
+        }
+        is_valid, errors = validate_evidence(evidence)
+        assert is_valid is True


### PR DESCRIPTION
## Plan IR + Evidence Schema 实现

### Plan IR Schema (schemas/plan-ir.schema.json)
- **7 种 action**：launch, shortcut, type, click, wait, assert, capture
- 每种 action 有独立的 params schema
- retry_policy 支持重试策略
- on_fail 支持 abort/skip/replan/human_review
- evidence 配置决定何时采集截图/UI tree

### Evidence Schema (schemas/evidence.schema.json)
- **4 种 status**：success, partial, failure, aborted
- **6 种错误分类**：plan_invalid, precondition_missing, capability_unavailable, environment_failure, observation_insufficient, assertion_failed
- step_result 记录 CLI 命令 + 输出
- assertions 记录断言结果
- repairs 记录修复尝试
- artifacts 指向实际文件目录

### Validator (src/schema/validator.py)
- `validate_plan()` / `validate_evidence()`
- `validate_plan_file()` / `validate_evidence_file()`
- `SchemaValidationError` 带详细错误信息

### Examples (schemas/examples/)
- 3 个 Plan 示例：Edge, Safari, Finder
- 2 个 Evidence 示例：success, partial with repair

### Tests
- tests/unit/test_schema.py

**+826 行代码**

Closes #19
Closes #20